### PR TITLE
[POS-563] Shorten bootstrapper filename

### DIFF
--- a/LevelUp.Integrations.TlsPatcher.Bootstrapper/LevelUp.Integrations.TlsPatcher.Bootstrapper.wixproj
+++ b/LevelUp.Integrations.TlsPatcher.Bootstrapper/LevelUp.Integrations.TlsPatcher.Bootstrapper.wixproj
@@ -91,7 +91,7 @@
     <PropertyGroup>
       <BuildScriptSourceDir>$(SolutionDir)BuildScripts\</BuildScriptSourceDir>
       <BuildScriptSourceDirSignBootstrapper>$(BuildScriptSourceDir)SignBootstrapper.ps1</BuildScriptSourceDirSignBootstrapper>
-      <BuildTargetFilename>$(TargetName)-$(GitVersion_NuGetVersion)_x86_x64$(TargetExt)</BuildTargetFilename>
+      <BuildTargetFilename>TlsPatcher-$(GitVersion_NuGetVersion)$(TargetExt)</BuildTargetFilename>
       <BuildTargetPath>$(TargetDir)$(BuildTargetFilename)</BuildTargetPath>
       <DeployTargetDir>$(SolutionDir)Deployment\</DeployTargetDir>
       <DeployTargetPath>$(DeployTargetDir)$(BuildTargetFilename)</DeployTargetPath>


### PR DESCRIPTION
@mmercurio if I understood the ticket correctly, you only wanted to shorten the filename, correct? While leaving the name that shows when installing or in add/remove programs as "LevelUp TLS Patcher v1.0.x"?